### PR TITLE
chore: bump typescript to 5.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "process": "^0.11.10",
         "react-dom": "18.2.0",
         "ts-jest": "29.4.1",
-        "typescript": "5.2.2"
+        "typescript": "^5.9.2"
       },
       "engines": {
         "npm": ">=8.15.0"
@@ -11438,7 +11438,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "process": "^0.11.10",
     "react-dom": "18.2.0",
     "ts-jest": "29.4.1",
-    "typescript": "5.2.2"
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- update TypeScript dev dependency to 5.9.2

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2e7fae8ac833382cd1791a368cf46