### PR TITLE
feat: redesign sign in dialog

### DIFF
--- a/src/__example__/SignInDialog.tsx
+++ b/src/__example__/SignInDialog.tsx
@@ -1,0 +1,59 @@
+import * as React from "react";
+
+const containerStyle: React.CSSProperties = {
+  width: "300px",
+};
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  boxSizing: "border-box",
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  marginTop: "8px",
+};
+
+const SignInDialog: React.FC = () => {
+  const [email, setEmail] = React.useState("");
+  const [sent, setSent] = React.useState(false);
+
+  const sendLink = (event: React.FormEvent) => {
+    event.preventDefault();
+    setSent(true);
+  };
+
+  const reset = () => {
+    setEmail("");
+    setSent(false);
+  };
+
+  return (
+    <div style={containerStyle}>
+      {sent ? (
+        <div>
+          <p>Please check your email for the magic link.</p>
+          <button type="button" onClick={reset} style={buttonStyle}>
+            Back to sign in
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={sendLink}>
+          <input
+            type="email"
+            required
+            value={email}
+            placeholder="Email address"
+            onChange={(e) => setEmail(e.target.value)}
+            style={inputStyle}
+          />
+          <button type="submit" style={buttonStyle}>
+            Send magic link
+          </button>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default SignInDialog;

--- a/src/__example__/index.tsx
+++ b/src/__example__/index.tsx
@@ -1,78 +1,8 @@
 import * as React from "react";
 import { createRoot } from "react-dom/client";
-import withReactFrameRate, { BaseUpdateProps } from "../index";
-
-type CircleProps = Readonly<{
-  deg: number;
-}> &
-  BaseUpdateProps;
-
-class Circle extends React.PureComponent<CircleProps> {
-  private static radius = 100;
-
-  public render() {
-    const rad = ((this.props.deg - 90) / 180) * Math.PI;
-    return (
-      <svg
-        width="200"
-        height="200"
-        viewBox="0 0 200 200"
-        preserveAspectRatio="none"
-      >
-        <circle
-          cx={Circle.radius}
-          cy={Circle.radius}
-          r="99"
-          stroke="black"
-          strokeWidth="1"
-          fill="yellow"
-        />
-        <line
-          x1={Circle.radius}
-          y1={Circle.radius}
-          x2={Circle.radius + Circle.radius * Math.cos(rad)}
-          y2={Circle.radius + Circle.radius * Math.sin(rad)}
-          strokeWidth="1"
-          stroke="red"
-        />
-      </svg>
-    );
-  }
-}
-
-const frameRate = 60;
-const initialDeg = -30;
-
-const App = () => {
-  const [isAnimating, setIsAnimating] = React.useState<boolean>(true);
-  const updateState = React.useCallback<(state: CircleProps) => CircleProps>(
-    (state: CircleProps) => {
-      const newDeg = state.deg + 6;
-      if (newDeg >= 270) {
-        setIsAnimating(false);
-      }
-      return {
-        ...state,
-        deg: newDeg,
-      };
-    },
-    []
-  );
-
-  const options = {
-    updateState,
-    frameRate,
-  };
-
-  const WithAnimation = React.useMemo(
-    () => withReactFrameRate<CircleProps>(options)(Circle),
-    []
-  );
-
-  return <WithAnimation deg={initialDeg} isAnimating={isAnimating} />;
-};
+import SignInDialog from "./SignInDialog";
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(document.getElementById("app")!);
 
-root.render(<App />);
+root.render(<SignInDialog />);


### PR DESCRIPTION
## Summary
- add a SignInDialog component that confirms magic link requests
- render the redesigned dialog in the example entry point

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a86d44b7608333b241981a0a5c4267